### PR TITLE
Redesign country heatmap front end for production polish

### DIFF
--- a/my-wrapped-frontend/src/components/LandingPage.jsx
+++ b/my-wrapped-frontend/src/components/LandingPage.jsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 const WrappedFMLanding = () => {
   const canvasRef = useRef(null);
   const animationRef = useRef(null);
-  const [isHovered, setIsHovered] = useState(false);
 
   // Data points for sparkline
   const sparklinePoints = useRef(

--- a/my-wrapped-frontend/src/components/LiveMapWrapper.jsx
+++ b/my-wrapped-frontend/src/components/LiveMapWrapper.jsx
@@ -23,17 +23,19 @@ export default function LiveMapWrapper() {
     return () => clearInterval(interval);
   }, []);
 
+  const isLoading = Object.keys(data.countryCounts).length === 0;
+
   return (
-    Object.keys(data.countryCounts).length === 0
-        ? <p>Loading map data...</p>
-        : <CountryHeatmapSlide
-            countryCounts={data.countryCounts}
-            countryTopArtists={data.countryTopArtists}
-          />
-      
-    // <CountryHeatmapSlide
-    //   countryCounts={data.countryCounts}
-    //   countryTopArtists={data.countryTopArtists}
-    // />
+    isLoading ? (
+      <div className="flex items-center justify-center w-full h-screen bg-slate-950 text-slate-300">
+        <span className="animate-pulse text-violet-400 mr-2">♪</span>
+        Loading map data...
+      </div>
+    ) : (
+      <CountryHeatmapSlide
+        countryCounts={data.countryCounts}
+        countryTopArtists={data.countryTopArtists}
+      />
+    )
   );
 }

--- a/my-wrapped-frontend/src/slides/CountryHeatmapSlide.jsx
+++ b/my-wrapped-frontend/src/slides/CountryHeatmapSlide.jsx
@@ -1,73 +1,92 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import * as d3 from "d3";
 import * as topojson from "topojson-client";
-import worldData from "../data/world-110m.json"; // ✅ relative path from slides folder
+import worldData from "../data/world-110m.json";
 
 export default function CountryHeatmapSlide({ countryCounts, countryTopArtists }) {
   const svgRef = useRef();
-  const [tooltipContent, setTooltipContent] = useState(null);
+  const [tooltip, setTooltip] = useState(null);
+
+  const countries = useMemo(
+    () => topojson.feature(worldData, worldData.objects.countries).features,
+    []
+  );
+
+  const maxCount = useMemo(() => d3.max(Object.values(countryCounts)), [countryCounts]);
+  const colorScale = useMemo(
+    () =>
+      d3
+        .scaleSequentialLog(d3.interpolatePlasma)
+        .domain([1, maxCount || 1]),
+    [maxCount]
+  );
 
   useEffect(() => {
     const svg = d3.select(svgRef.current);
     const width = window.innerWidth;
     const height = window.innerHeight;
-
     svg.selectAll("*").remove();
     svg.attr("viewBox", [0, 0, width, height]);
 
     const projection = d3.geoNaturalEarth1().scale(width / 6.5).translate([width / 2, height / 2]);
     const path = d3.geoPath().projection(projection);
 
-    const maxCount = d3.max(Object.values(countryCounts));
-    const colorScale = d3
-      .scaleSequentialSqrt(d3.interpolateTurbo)
-      .domain([0, maxCount || 1]);
-
-    const countries = topojson.feature(worldData, worldData.objects.countries);
-
     svg
       .append("g")
       .selectAll("path")
-      .data(countries.features)
+      .data(countries)
       .join("path")
       .attr("d", path)
       .attr("fill", d => {
-        const name = d.properties.name;
-        const count = countryCounts[name] || 0;
-        return count > 0 ? colorScale(count) : "#1e1e2e";
+        const count = countryCounts[d.properties.name] || 0;
+        return count ? colorScale(count) : "#222";
       })
-      .attr("stroke", "#ffffff33")
+      .attr("stroke", "#00000055")
       .attr("stroke-width", 0.5)
-      .on("mousemove", (event, d) => {
+      .on("mousemove", function (event, d) {
+        const [x, y] = d3.pointer(event);
         const name = d.properties.name;
         const count = countryCounts[name] || 0;
         const topArtists = countryTopArtists[name] || [];
-        const artistList = topArtists.length > 0 ? topArtists.join(", ") : "No data";
-        setTooltipContent(`${name} — ${count} plays\nTop Artists: ${artistList}`);
+        const artistList = topArtists.length ? topArtists.join(", ") : "No data";
+        d3.select(this).attr("stroke", "#fff").attr("stroke-width", 1.2);
+        setTooltip({ x, y, name, count, artistList });
       })
-      .on("mouseout", () => {
-        setTooltipContent(null);
+      .on("mouseout", function () {
+        d3.select(this).attr("stroke", "#00000055").attr("stroke-width", 0.5);
+        setTooltip(null);
       });
-  }, [countryCounts, countryTopArtists]);
+  }, [countries, countryCounts, countryTopArtists, colorScale]);
 
   return (
-    <div className="relative w-full h-screen overflow-hidden bg-gradient-to-b from-[#050026] to-[#120933]">
-    <svg ref={svgRef} className="absolute inset-0 w-full h-full" />
+    <div className="relative w-full h-screen overflow-hidden bg-gradient-to-b from-slate-950 via-violet-950 to-slate-900 text-white">
+      <svg ref={svgRef} className="absolute inset-0 w-full h-full" />
 
-    {tooltipContent && (
-      <div className="fixed top-1/2 right-6 transform -translate-y-1/2 w-72 bg-white/10 text-white p-4 rounded-xl backdrop-blur-md shadow-xl text-sm font-mono whitespace-pre-wrap z-50">
-        {tooltipContent}
+      {tooltip && (
+        <div
+          className="pointer-events-none absolute z-20 bg-slate-900/90 border border-white/20 rounded-lg px-3 py-2 text-xs shadow-lg backdrop-blur"
+          style={{ left: tooltip.x + 15, top: tooltip.y }}
+        >
+          <p className="font-semibold">{tooltip.name}</p>
+          <p>{tooltip.count} plays</p>
+          <p className="mt-1 text-[10px] text-violet-200">Top Artists: {tooltip.artistList}</p>
+        </div>
+      )}
+
+      <header className="absolute top-8 left-1/2 -translate-x-1/2 text-center z-10">
+        <h1 className="text-5xl font-bold tracking-tight bg-gradient-to-r from-violet-400 to-rose-400 bg-clip-text text-transparent drop-shadow-lg">
+          Where Your Music Comes From
+        </h1>
+        <p className="mt-2 text-sm text-slate-300 max-w-lg mx-auto">
+          Hover over a country to reveal your play count and top artists from that region.
+        </p>
+      </header>
+
+      <div className="absolute bottom-12 left-1/2 -translate-x-1/2 flex items-center text-xs text-slate-300 z-10">
+        <span className="mr-2">Less</span>
+        <div className="h-2 w-48 bg-gradient-to-r from-violet-900 via-fuchsia-600 to-yellow-300 rounded" />
+        <span className="ml-2">More</span>
       </div>
-    )}
-
-    <div className="absolute top-10 left-10 text-white z-10">
-      <h1 className="text-4xl font-bold text-cyan-300 drop-shadow">Where Your Music Comes From</h1>
-      <p className="text-sm text-magenta-100 mt-2 max-w-md">
-        This map visualizes the total number of scrobbles from artists based in each country. Hover over a country to see details.
-      </p>
     </div>
-  </div>
-
-
   );
 }


### PR DESCRIPTION
## Summary
- Replace CountryHeatmapSlide with a polished redesign: Plasma color scale, dynamic cursor tooltip, gradient background and legend.
- Add refined loading state and structure in LiveMapWrapper.
- Remove unused state from LandingPage to satisfy lint.

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae49577108832fade4f6be9ee218ca